### PR TITLE
Various tokenizer fixes/improvements

### DIFF
--- a/src/tokenizer/tokenizer.py
+++ b/src/tokenizer/tokenizer.py
@@ -1643,6 +1643,7 @@ def parse_date_and_time(token_stream):
                     "Júl",
                     "des",
                     "Des",
+                    "Ágúst",
                 }:
                     token = TOK.Daterel(token.txt, y=0, m=month, d=0)
 

--- a/test/test_tokenizer.py
+++ b/test/test_tokenizer.py
@@ -58,6 +58,8 @@ def test_single_tokens():
         ("klukkan þrjú", [Tok(TOK.TIME, "klukkan þrjú", (3, 00, 0))]),
         ("17/6", [Tok(TOK.DATEREL, "17/6", (0, 6, 17))]),
         ("3. maí", [Tok(TOK.DATEREL, "3. maí", (0, 5, 3))]),
+        ("Ágúst", TOK.WORD), # On its own, it
+        ("13. ágúst", [Tok(TOK.DATEREL, "13. ágúst", (0, 8, 13))]),
         ("nóvember 1918", [Tok(TOK.DATEREL, "nóvember 1918", (1918, 11, 0))]),
         ("sautjánda júní", [Tok(TOK.DATEREL, "sautjánda júní", (0, 6, 17))]),
         (
@@ -394,6 +396,11 @@ def test_sentences():
     test_sentence(
         "Byrjum á 2½ dl af rjóma því ¼-½ matskeið er ekki nóg. Helmingur er ½. Svarið er 42, ekki 41⅞.",
         "B    W W ME    W  W     W  N P N W       W  W    W P E B W       W N P E B W W  N P W    N P E",
+    )
+
+    test_sentence(
+        "Ágúst og frændi hans, sem hét líka Ágúst, hittust í ágúst, nánar tiltekið 13. ágúst 2018.",
+        "B   W W  W      W   P W   W   W    W    P W       W DR   P W     W        DA            P E",
     )
 
 

--- a/test/test_tokenizer.py
+++ b/test/test_tokenizer.py
@@ -58,7 +58,7 @@ def test_single_tokens():
         ("klukkan þrjú", [Tok(TOK.TIME, "klukkan þrjú", (3, 00, 0))]),
         ("17/6", [Tok(TOK.DATEREL, "17/6", (0, 6, 17))]),
         ("3. maí", [Tok(TOK.DATEREL, "3. maí", (0, 5, 3))]),
-        ("Ágúst", TOK.WORD), # On its own, it
+        ("Ágúst", TOK.WORD), # Not month name if capitalized
         ("13. ágúst", [Tok(TOK.DATEREL, "13. ágúst", (0, 8, 13))]),
         ("nóvember 1918", [Tok(TOK.DATEREL, "nóvember 1918", (1918, 11, 0))]),
         ("sautjánda júní", [Tok(TOK.DATEREL, "sautjánda júní", (0, 6, 17))]),
@@ -339,8 +339,9 @@ def test_sentences():
 
     # '\u00AD': soft hyphen
     # '\u200B': zero-width space
+    # '\uFEFF': zero-width non-breaking space
     test_sentence(
-        "Lands\u00ADbank\u00ADinn er í 98\u200B,2 pró\u00ADsent eigu\u200B íslenska rík\u00ADis\u00ADins.",
+        "Lands\u00ADbank\u00ADinn er í 98\u200B,2 pró\u00ADsent eigu\u200B íslenska rík\uFEFFis\u00ADins.",
         "B W                      W  W PC                       W          W        W                  P E"
     )
 
@@ -416,8 +417,8 @@ def test_sentences():
     )
 
     test_sentence(
-        "Ágúst og frændi hans, sem hét líka Ágúst, hittust í ágúst, nánar tiltekið 13. ágúst 2018.",
-        "B   W W  W      W   P W   W   W    W    P W       W DR   P W     W        DA            P E",
+        "Ágúst bjó á hæð númer 13. Ágúst kunni vel við það, enda var 12. ágúst. ÞAÐ VAR 12. ÁGÚST!",
+        "B   W W   W W   W    N P E B W     W     W   W   W P  W    W   DR  P E B W W   DR      P E",
     )
 
 

--- a/test/test_tokenizer.py
+++ b/test/test_tokenizer.py
@@ -337,6 +337,13 @@ def test_sentences():
         "B W P W    W W         W      W   W A    P W N P P E  B W P E B W W     W  W    W    A   P E",
     )
 
+    # '\u00AD': soft hyphen
+    # '\u200B': zero-width space
+    test_sentence(
+        "Lands\u00ADbank\u00ADinn er í 98\u200B,2 pró\u00ADsent eigu\u200B íslenska rík\u00ADis\u00ADins.",
+        "B W                      W  W PC                       W          W        W                  P E"
+    )
+
     test_sentence(
         "Málið um BSRB gekk marg-ítrekað til stjórnskipunar- og eftirlitsnefndar í 10. sinn "
         "skv. XVII. kafla þann 24. september 2015 nk. Ál-verið notar 60 MWst á ári.",

--- a/test/test_tokenizer.py
+++ b/test/test_tokenizer.py
@@ -223,9 +223,14 @@ def test_single_tokens():
         ("€472,64", TOK.AMOUNT),
         ("$1.472,64", TOK.AMOUNT),
         ("€3.472,64", TOK.AMOUNT),
+        ("£1.922", TOK.AMOUNT),
+        ("¥212,11", TOK.AMOUNT),
         ("$1,472.64", [Tok(TOK.AMOUNT, "$1.472,64", (1472.64, "USD", None, None))]),
         ("€3,472.64", [Tok(TOK.AMOUNT, "€3.472,64", (3472.64, "EUR", None, None))]),
+        ("£5,199.99", [Tok(TOK.AMOUNT, "£5.199,99", (5199.99, "GBP", None, None))]),
         ("fake@news.is", TOK.EMAIL),
+        ("jon.jonsson.99@netfang.is", TOK.EMAIL),
+        ("valid@my-domain.reallylongtld", TOK.EMAIL),
         ("7a", [Tok(TOK.NUMWLETTER, "7a", (7, "a"))]),
         ("33B", [Tok(TOK.NUMWLETTER, "33B", (33, "B"))]),
         ("1129c", [Tok(TOK.NUMWLETTER, "1129c", (1129, "c"))]),
@@ -325,6 +330,11 @@ def test_sentences():
         "Í dag er 10. júlí. Klukkan er 15:40 núna.Ég fer kl. 13 niður á Hlemm o.s.frv. ",
         "B W     W     P E B W W A       W W      P A    W  A  P E B W W   W  N     P E "
         "B W W W  DR      P E B W   W  T     W   P E B W W T     W     W W     W      P E",
+    )
+
+    test_sentence(
+        "Jæja, bjór í Bretlandi kominn upp í £4.29 (ISK 652).  Dýrt!     Í Japan er hann bara ¥600.",
+        "B W P W    W W         W      W   W A    P W N P P E  B W P E B W W     W  W    W    A   P E",
     )
 
     test_sentence(


### PR DESCRIPTION
Fixed issue where "Ágúst" (capitalised - masc. icel. name) was tokenized as a relative date. Strings such as "21. Ágúst" are still parsed as a rel. date. Should I change this? It is unlikely, but possible, that this might cause issues in an enumerated list of names, e.g. ("1. Ágúst Jónsson"). 

Unwanted characters such as soft hyphens and zero-width spaces are now removed before tokenization.

Added support for more currency symbols such as sterlin, yen, ruble, and abstracted currency symbol parsing to remove duplicate logic.

Also added tests for all this stuff.